### PR TITLE
Initialize project skeleton for QuizMaster Pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Backend
+backend/target/
+
+# Frontend
+frontend/node_modules/
+frontend/build/
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# QuizMaster Pro
+
+This repository contains a minimal skeleton for the QuizMaster Pro platform.
+
+- `backend` - Spring Boot application exposing a sample REST endpoint.
+- `frontend` - React + TypeScript application with a basic entry point.
+
+Both modules are placeholders for future development.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.quizmasterpro</groupId>
+  <artifactId>backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>backend</name>
+  <description>QuizMaster Pro backend skeleton</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/backend/src/main/java/com/quizmasterpro/BackendApplication.java
+++ b/backend/src/main/java/com/quizmasterpro/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.quizmasterpro;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/controller/HelloController.java
+++ b/backend/src/main/java/com/quizmasterpro/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.quizmasterpro.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/api/hello")
+    public String hello() {
+        return "Hello from QuizMaster Pro";
+    }
+}

--- a/backend/src/test/java/com/quizmasterpro/BackendApplicationTests.java
+++ b/backend/src/test/java/com/quizmasterpro/BackendApplicationTests.java
@@ -1,0 +1,12 @@
+package com.quizmasterpro;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+.env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quizmasterpro-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'No start script defined'",
+    "build": "echo 'No build script defined'",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "^5.0.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QuizMaster Pro</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function App() {
+  return <div>QuizMaster Pro Frontend</div>;
+}
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot backend with sample REST endpoint
- add React + TypeScript frontend starter
- add root and frontend gitignore and repo README

## Testing
- `mvn -q test -f backend/pom.xml` *(fails: Non-resolvable parent POM... network is unreachable)*
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6896211cf424832eab2c70384449c712