### PR TITLE
Add basic category management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Backend
+backend/target/
+
+# Frontend
+frontend/node_modules/
+frontend/build/
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# QuizMaster Pro
+
+This repository contains a minimal skeleton for the QuizMaster Pro platform.
+
+- `backend` - Spring Boot application with sample REST endpoints and simple
+  PostgreSQL-backed `User` and `Category` APIs.
+- `frontend` - React + TypeScript application with a basic entry point and forms
+  to add and list users and categories.
+
+Both modules are placeholders for future development.
+
+## Development Status
+
+### Completed Pages
+- Basic user list and creation form in the React frontend interacting with the `User` API.
+- Simple login page posting to a backend `/api/auth/login` endpoint.
+- Category list and creation form interacting with the `Category` API.
+
+### Pages to Develop
+- Public: Landing, Authentication (login/register), Pricing.
+- Admin: Dashboard, User Management, Category Management, Question Bank, Exam Creation, Results & Analytics.
+- User: Exam Portal, Exam Interface, Results page.
+
+This list follows the high-level requirements for QuizMaster Pro and will expand as the platform evolves.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.quizmasterpro</groupId>
+  <artifactId>backend</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>backend</name>
+  <description>QuizMaster Pro backend skeleton</description>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/backend/src/main/java/com/quizmasterpro/BackendApplication.java
+++ b/backend/src/main/java/com/quizmasterpro/BackendApplication.java
@@ -1,0 +1,11 @@
+package com.quizmasterpro;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/controller/AuthController.java
+++ b/backend/src/main/java/com/quizmasterpro/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.quizmasterpro.controller;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.quizmasterpro.model.User;
+import com.quizmasterpro.repository.UserRepository;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final UserRepository userRepository;
+
+    public AuthController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, String>> login(@RequestBody LoginRequest request) {
+        Optional<User> user = userRepository.findByEmail(request.email());
+        if (user.isPresent()) {
+            return ResponseEntity.ok(Map.of("message", "Login successful"));
+        }
+        return ResponseEntity.status(401).body(Map.of("message", "Invalid credentials"));
+    }
+
+    public record LoginRequest(String email, String password) {}
+}

--- a/backend/src/main/java/com/quizmasterpro/controller/CategoryController.java
+++ b/backend/src/main/java/com/quizmasterpro/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.quizmasterpro.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.quizmasterpro.model.Category;
+import com.quizmasterpro.repository.CategoryRepository;
+
+@RestController
+@RequestMapping("/api/categories")
+public class CategoryController {
+    private final CategoryRepository repository;
+
+    public CategoryController(CategoryRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Category> all() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    public Category create(@RequestBody Category category) {
+        return repository.save(category);
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/controller/HelloController.java
+++ b/backend/src/main/java/com/quizmasterpro/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.quizmasterpro.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/api/hello")
+    public String hello() {
+        return "Hello from QuizMaster Pro";
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/controller/UserController.java
+++ b/backend/src/main/java/com/quizmasterpro/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.quizmasterpro.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.quizmasterpro.model.User;
+import com.quizmasterpro.repository.UserRepository;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserRepository repository;
+
+    public UserController(UserRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<User> all() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    public User create(@RequestBody User user) {
+        return repository.save(user);
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/model/Category.java
+++ b/backend/src/main/java/com/quizmasterpro/model/Category.java
@@ -1,0 +1,44 @@
+package com.quizmasterpro.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    public Category() {}
+
+    public Category(String name, Category parent) {
+        this.name = name;
+        this.parent = parent;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Category getParent() {
+        return parent;
+    }
+
+    public void setParent(Category parent) {
+        this.parent = parent;
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/model/User.java
+++ b/backend/src/main/java/com/quizmasterpro/model/User.java
@@ -1,0 +1,40 @@
+package com.quizmasterpro.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String email;
+
+    public User() {}
+
+    public User(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/backend/src/main/java/com/quizmasterpro/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/quizmasterpro/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.quizmasterpro.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.quizmasterpro.model.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {}

--- a/backend/src/main/java/com/quizmasterpro/repository/UserRepository.java
+++ b/backend/src/main/java/com/quizmasterpro/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.quizmasterpro.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.quizmasterpro.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/quizmasterpro
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    parent_id INTEGER REFERENCES categories(id)
+);

--- a/backend/src/test/java/com/quizmasterpro/BackendApplicationTests.java
+++ b/backend/src/test/java/com/quizmasterpro/BackendApplicationTests.java
@@ -1,0 +1,12 @@
+package com.quizmasterpro;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+.env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "quizmasterpro-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'No start script defined'",
+    "build": "echo 'No build script defined'",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "react-scripts": "^5.0.1",
+    "typescript": "^5.0.0",
+    "@types/react-router-dom": "^5.3.3"
+  },
+  "proxy": "http://localhost:8080"
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QuizMaster Pro</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import LoginPage from './pages/Login';
+import UsersPage from './pages/Users';
+import CategoriesPage from './pages/Categories';
+
+const App: React.FC = () => {
+  return (
+    <Router>
+      <nav>
+        <Link to="/login">Login</Link> |{' '}
+        <Link to="/users">Users</Link> |{' '}
+        <Link to="/categories">Categories</Link>
+      </nav>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/users" element={<UsersPage />} />
+        <Route path="/categories" element={<CategoriesPage />} />
+      </Routes>
+    </Router>
+  );
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+const CategoriesPage: React.FC = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [name, setName] = useState('');
+
+  const loadCategories = async () => {
+    const res = await fetch('/api/categories');
+    const data = await res.json();
+    setCategories(data);
+  };
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/categories', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    setName('');
+    loadCategories();
+  };
+
+  return (
+    <div>
+      <h1>Categories</h1>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+        <button type="submit">Add Category</button>
+      </form>
+      <ul>
+        {categories.map(c => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CategoriesPage;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+const LoginPage: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    setMessage(data.message);
+  };
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+const UsersPage: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  const loadUsers = async () => {
+    const res = await fetch('/api/users');
+    const data = await res.json();
+    setUsers(data);
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email })
+    });
+    setName('');
+    setEmail('');
+    loadUsers();
+  };
+
+  return (
+    <div>
+      <h1>QuizMaster Pro Users</h1>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <button type="submit">Add User</button>
+      </form>
+      <ul>
+        {users.map(u => (
+          <li key={u.id}>{u.name} ({u.email})</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default UsersPage;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- define Category JPA entity and expose `/api/categories` endpoints
- add React page and route to list and create categories
- document new Category API and page

## Testing
- `mvn -q test -f backend/pom.xml` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6896211cf424832eab2c70384449c712